### PR TITLE
Monk: Add Monk Kit on master branch

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,0 +1,11 @@
+FROM node:16-alpine as build-stage
+WORKDIR /app
+COPY cmd/client/package*.json ./
+RUN npm install
+COPY cmd/client/ .
+RUN npm run build:production
+
+FROM nginx:stable-alpine as production-stage
+COPY --from=build-stage /app/dist /usr/share/nginx/html
+EXPOSE 8080
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -1,0 +1,21 @@
+FROM golang:1.18 AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the entire source code from the current directory to the PWD(Present Working Directory) inside the container
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o lambda cmd/lambda/main.go
+
+# Final stage: Run the built binary
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+
+# Copy the binary from the builder stage
+COPY --from=builder /app/lambda .
+
+CMD ["./lambda"]

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,14 @@
+FROM golang:1.18 AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY cmd/server/*.go ./cmd/server/
+COPY internal/ ./internal/
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o server ./cmd/server
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=builder /app/server .
+EXPOSE 8080
+CMD ["./server"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO hex-monscape
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,151 @@
+namespace: hex-monscape
+
+client:
+  defines: runnable
+  metadata:
+    name: client
+    description: Web UI for Hex Monscape game, built with Vue 3 + Vite.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    client:
+      image: env-3251.registry.local/client:master-51cea85
+      build: .
+      dockerfile: Dockerfile.client
+  services:
+    http-server:
+      description: Port for serving the web UI
+      container: client
+      port: 8080
+      host-port: 8080
+      publish: true
+      protocol: tcp
+  connections:
+    api-server-connection:
+      target: hex-monscape/server
+      service: server-port
+      optional: true
+      description: >-
+        Connection to the server component of the game application for API
+        requests
+  variables:
+    vite-api-stage-path:
+      env: VITE_API_STAGE_PATH
+      type: string
+      value: <- connection-hostname("api-server-connection")
+      description: API Gateway required stage path for routing
+
+lambda:
+  defines: runnable
+  metadata:
+    name: lambda
+    description: AWS Lambda function for online game demo.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    lambda:
+      image: env-3251.registry.local/lambda:master-51cea85
+      build: .
+      dockerfile: Dockerfile.lambda
+  services:
+    lambda-service-port:
+      description: Port for the Lambda service when running in server mode
+      container: lambda
+      port: 9186
+      host-port: 9186
+      publish: true
+      protocol: tcp
+  connections:
+    dynamodb-connection:
+      target: hex-monscape/dynamodb
+      service: dynamodb-port
+      optional: true
+      description: Connection to AWS DynamoDB for game data storage
+  variables:
+    localstack-endpoint:
+      env: LOCALSTACK_ENDPOINT
+      type: string
+      value: http://localhost:4566
+      description: Endpoint for Localstack, used for local development
+    battle-table:
+      env: BATTLE_TABLE
+      type: string
+      value: battles
+      description: DynamoDB table name for battles
+    game-table:
+      env: GAME_TABLE
+      type: string
+      value: games
+      description: DynamoDB table name for game state
+    monster-table:
+      env: MONSTER_TABLE
+      type: string
+      value: monsters
+      description: DynamoDB table name for monsters
+
+server:
+  defines: runnable
+  metadata:
+    name: server
+    description: Server component of the game application.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    server:
+      image: env-3251.registry.local/server:master-51cea85
+      build: .
+      dockerfile: Dockerfile.server
+  services:
+    server-port:
+      description: Port exposed by the server service for incoming connections
+      container: server
+      port: $port
+      host-port: $port
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables:
+    port:
+      env: PORT
+      type: string
+      value: 8080
+      description: Port on which the server service will run
+    storage-type:
+      env: STORAGE_TYPE
+      type: string
+      value: memory
+      description: Type of storage to use, can be memory, dynamodb, or mysql
+    monster-data-path:
+      env: MONSTER_DATA_PATH
+      type: string
+      value: /data/monsters.json
+      description: File path for monster data, used when storage type is memory
+    localstack-endpoint:
+      env: LOCALSTACK_ENDPOINT
+      type: string
+      value: null
+      description: Localstack endpoint for DynamoDB, used when storage type is dynamodb
+    battle-table-name:
+      env: BATTLE_TABLE_NAME
+      type: string
+      value: null
+      description: DynamoDB table name for battles, used when storage type is dynamodb
+    game-table-name:
+      env: GAME_TABLE_NAME
+      type: string
+      value: null
+      description: DynamoDB table name for games, used when storage type is dynamodb
+    monster-table-name:
+      env: MONSTER_TABLE_NAME
+      type: string
+      value: null
+      description: DynamoDB table name for monsters, used when storage type is dynamodb
+    sql-dsn:
+      env: SQL_DSN
+      type: string
+      value: null
+      description: Data Source Name for MySQL, used when storage type is mysql
+
+stack:
+  defines: group
+  members:
+    - hex-monscape/client
+    - hex-monscape/lambda
+    - hex-monscape/server


### PR DESCRIPTION
### Containerization and Deployment Configuration for Hex-Monscape

#### Summary of Changes
I've successfully containerized the Hex-Monscape application and prepared it for deployment. The application consists of three primary services: a web UI client, an AWS Lambda function, and a server. The following Dockerfiles and configurations have been added:

- `Dockerfile.client`: Builds the client service using a two-stage process with Node.js and Nginx. The service exposes port 8080 and uses the environment variable `VITE_API_STAGE_PATH`.
- `Dockerfile.server`: Sets up the server service, which listens on port 8080 defined by the `PORT` environment variable. The server is a standalone service and does not connect to other services within the repository.
- `Dockerfile.lambda`: Constructs the lambda service, which requires environment variables for DynamoDB table names (`battle_table`, `game_table`, `monster_table`) and the `localstack_endpoint` for local development.

Additionally, a `monk.yaml` file and a `MANIFEST` file have been created to facilitate deployment using Monk.

#### Encountered Issues
During the process, I encountered a few issues:

- The server's Dockerfile build initially failed due to missing Go modules. This was resolved by ensuring all necessary files and directories were copied into the Docker build context.
- The client's Dockerfile build failed because the `npm run build` script was missing. I updated the Dockerfile to use the correct build script from the package.json file.
- The lambda service's Dockerfile build also failed due to missing Go modules. This was fixed by copying the entire source code of the service into the container before building the Go application.

#### Deployment Instructions
The application is now ready for deployment. To proceed, merge this PR, and the application will be re-deployed on each subsequent push. Ensure that the environment variables for the lambda service are correctly set with the DynamoDB table names and that the `VITE_API_STAGE_PATH` for the client service is provided.

#### Final Notes
The testing services (`localstack` and `mysql`) defined in the `docker-compose.yml` are external and used solely for testing purposes. They are not part of the main application deployment. The lambda service is expected to connect to AWS DynamoDB, which is a third-party service. The client and server services may require a database connection, but this has not been explicitly configured as part of this process.